### PR TITLE
Configure Prisma schema and client for SQLite

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 PORT=3000
+DATABASE_URL="file:./prisma/dev.db"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   },
   "dependencies": {
     "dotenv": "^16.4.5",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "@prisma/client": "^5.18.0"
+  },
+  "devDependencies": {
+    "prisma": "^5.18.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,39 @@
+// This file defines the Prisma schema for the tibia-exp-tracker project.
+// It configures SQLite as the datasource and defines the Guild, Player,
+// and DailyExp models with their respective relations and constraints.
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model Guild {
+  id    Int     @id @default(autoincrement())
+  name  String
+  world String
+  dailyExp DailyExp[]
+
+  @@unique([name, world])
+}
+
+model Player {
+  id   Int    @id @default(autoincrement())
+  name String @unique
+  dailyExp DailyExp[]
+}
+
+model DailyExp {
+  id          Int      @id @default(autoincrement())
+  player      Player   @relation(fields: [playerId], references: [id])
+  playerId    Int
+  guild       Guild    @relation(fields: [guildId], references: [id])
+  guildId     Int
+  runDate     DateTime
+  expYesterday Int
+
+  @@unique([playerId, guildId, runDate])
+}

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,5 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export { prisma };


### PR DESCRIPTION
## Summary
- add Prisma and @prisma/client dependencies and set SQLite database URL
- define Prisma schema for guilds, players, and daily experience tracking
- expose a reusable Prisma client for the application

## Testing
- not run (environment only)

------
https://chatgpt.com/codex/tasks/task_e_68dfdb73fccc832eace73a8339e53d6b