### PR TITLE
Add guild fetch service

### DIFF
--- a/src/services/guilds.js
+++ b/src/services/guilds.js
@@ -1,0 +1,21 @@
+const axios = require('axios');
+
+async function fetchGuilds(world) {
+  const url = `https://api.tibiadata.com/v4/guilds/${encodeURIComponent(world)}`;
+
+  try {
+    const response = await axios.get(url);
+    const guilds = response?.data?.guilds?.guilds_list ?? [];
+
+    const names = guilds
+      .map((guild) => (typeof guild?.name === 'string' ? guild.name.trim() : ''))
+      .filter((name) => name.length > 0);
+
+    return [...new Set(names)];
+  } catch (error) {
+    console.error('Failed to fetch guilds:', error);
+    return [];
+  }
+}
+
+module.exports = { fetchGuilds };


### PR DESCRIPTION
## Summary
- add a guild service that fetches guild names for a given world from the TibiaData API
- trim names, remove duplicates, and handle request errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe1105e68832ea9750ed70d643c52