### PR TITLE
Add daily cron job for guild scraping

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "dotenv": "^16.4.5",
     "express": "^4.18.2",
-    "@prisma/client": "^5.18.0"
+    "@prisma/client": "^5.18.0",
+    "node-cron": "^3.0.3"
   },
   "devDependencies": {
     "prisma": "^5.18.0"

--- a/src/jobs/dailyJob.js
+++ b/src/jobs/dailyJob.js
@@ -1,0 +1,68 @@
+require('dotenv').config();
+
+const cron = require('node-cron');
+
+const { fetchGuilds } = require('../services/guilds');
+const { scrapeGuildMembers } = require('../services/scraper');
+const { saveDailyExp } = require('../services/save');
+
+const WORLD = process.env.WORLD;
+const CRON_SCHEDULE = process.env.CRON_SCHEDULE || '0 0 * * *';
+
+if (!WORLD) {
+  throw new Error('WORLD environment variable must be defined');
+}
+
+async function runDailyJob(world, runDate = new Date()) {
+  try {
+    const guilds = await fetchGuilds(world);
+
+    for (const guildName of guilds) {
+      try {
+        const members = await scrapeGuildMembers(guildName);
+        const playersCount = members.length;
+        const totalExp = members.reduce((sum, member) => {
+          const value =
+            typeof member.exp_yesterday === 'number'
+              ? member.exp_yesterday
+              : Number.parseInt(member.exp_yesterday ?? member.expYesterday ?? 0, 10);
+
+          if (Number.isNaN(value)) {
+            return sum;
+          }
+
+          return sum + value;
+        }, 0);
+
+        await saveDailyExp({
+          guildName,
+          world,
+          runDate,
+          items: members,
+        });
+
+        console.log('[dailyJob] Summary', {
+          guild: guildName,
+          playersCount,
+          totalExp,
+        });
+      } catch (guildError) {
+        console.error(`[dailyJob] Failed processing guild ${guildName}:`, guildError);
+      }
+    }
+  } catch (error) {
+    console.error('[dailyJob] Failed to execute job:', error);
+  }
+}
+
+const job = cron.schedule(
+  CRON_SCHEDULE,
+  () => {
+    runDailyJob(WORLD, new Date());
+  },
+  { scheduled: false }
+);
+
+job.start();
+
+module.exports = { job, runDailyJob };


### PR DESCRIPTION
## Summary
- add a scheduled job that fetches guilds, scrapes members, and saves their daily experience
- read WORLD and CRON_SCHEDULE from the environment and log a processing summary
- include node-cron dependency for scheduling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfe62cf3ac832e82feae3da8665184